### PR TITLE
Robot too close

### DIFF
--- a/line_robots/canvas.cpp
+++ b/line_robots/canvas.cpp
@@ -86,15 +86,25 @@ QGraphicsLineItem* Canvas::detectLine(int *x, int *y){
     int maxY = this->sceneRect().height()-LINE_SEARCH_RADIUS;
     if ((*x > LINE_SEARCH_RADIUS && *x < maxX) && (*y > LINE_SEARCH_RADIUS && *y < maxY)) {
         // detect line in 60px radius of drop location
-        for (int i = -LINE_SEARCH_RADIUS; i <= LINE_SEARCH_RADIUS; i++) {
-            for (int j = -LINE_SEARCH_RADIUS; j <= LINE_SEARCH_RADIUS; j++) {
+        for (int i = 0; i <= LINE_SEARCH_RADIUS; i++) {
+            for (int j = 0; j <= LINE_SEARCH_RADIUS; j++) {
                 curItem = itemAt(*x + i, *y + j, QTransform());
                 if ((line = dynamic_cast<QGraphicsLineItem*>(curItem))) {
                     *x+=i; //adjust coordinates
                     *y+=j;
                     return line;
                 }
-           }
+            }
+        }
+        for (int i = 0; i >= -LINE_SEARCH_RADIUS; i--) {
+            for (int j = 0; j >= -LINE_SEARCH_RADIUS; j--){
+                curItem = itemAt(*x + i, *y + j, QTransform());
+                if ((line = dynamic_cast<QGraphicsLineItem*>(curItem))) {
+                    *x+=i; //adjust coordinates
+                    *y+=j;
+                    return line;
+                }
+            }
         }
     }
     return nullptr; // so we can detect found state in caller

--- a/line_robots/canvas.cpp
+++ b/line_robots/canvas.cpp
@@ -51,11 +51,18 @@ void Canvas::dropEvent(QGraphicsSceneDragDropEvent *event)
              addItem(newLine);
         } else if (dragObjectType.contains("Robot")) { // dragging a robot object onto the canvas
            QGraphicsLineItem *lineDroppedOn = detectLine(&x,&y);
+
            if (lineDroppedOn){
-               Robot* newRobot = new Robot(x + 10, y - 10, lineDroppedOn, dragObjectType);
-               newRobot->setSpeed(10);
-               newRobot->setZValue(1);
-               addItem(newRobot);
+               if (detectRobot(&x, &y)) {
+                   event->ignore();
+                   errorMsg(4);
+               }
+               else {
+                   Robot* newRobot = new Robot(x + 10, y - 10, lineDroppedOn, dragObjectType);
+                   newRobot->setSpeed(10);
+                   newRobot->setZValue(1);
+                   addItem(newRobot);
+               }
            }
            else if (lineDroppedOn == nullptr && items().count() == 0){ // attempting to add robot with no lines in the canvas
                event->ignore();
@@ -75,15 +82,12 @@ QGraphicsLineItem* Canvas::detectLine(int *x, int *y){
     QGraphicsItem *curItem;
     QGraphicsLineItem *line;
 
-    // TODO: Add some type of error statement if the user tries to place
-    // the line it doesn't let them
-    // if statement ensure not placing too close to boundary to start
-    int maxX = this->sceneRect().width()-SEARCH_RADIUS;
-    int maxY = this->sceneRect().height()-SEARCH_RADIUS;
-    if ((*x > SEARCH_RADIUS && *x < maxX) && (*y > SEARCH_RADIUS && *y < maxY)) {
-    // detect line in 60px radius of drop location
-        for (int i = -SEARCH_RADIUS; i <= SEARCH_RADIUS; i++) {
-            for (int j = -SEARCH_RADIUS; j <= SEARCH_RADIUS; j++) {
+    int maxX = this->sceneRect().width()-LINE_SEARCH_RADIUS;
+    int maxY = this->sceneRect().height()-LINE_SEARCH_RADIUS;
+    if ((*x > LINE_SEARCH_RADIUS && *x < maxX) && (*y > LINE_SEARCH_RADIUS && *y < maxY)) {
+        // detect line in 60px radius of drop location
+        for (int i = -LINE_SEARCH_RADIUS; i <= LINE_SEARCH_RADIUS; i++) {
+            for (int j = -LINE_SEARCH_RADIUS; j <= LINE_SEARCH_RADIUS; j++) {
                 curItem = itemAt(*x + i, *y + j, QTransform());
                 if ((line = dynamic_cast<QGraphicsLineItem*>(curItem))) {
                     *x+=i; //adjust coordinates
@@ -93,7 +97,28 @@ QGraphicsLineItem* Canvas::detectLine(int *x, int *y){
            }
         }
     }
-    return nullptr; //so we can detect found state in caller
+    return nullptr; // so we can detect found state in caller
+}
+
+bool Canvas::detectRobot(int *x, int *y){
+    QGraphicsItem *curItem;
+    Robot *robot;
+
+    int maxX = this->sceneRect().width()-ROBOT_SEARCH_RADIUS;
+    int maxY = this->sceneRect().height()-ROBOT_SEARCH_RADIUS;
+
+    if ((*x > ROBOT_SEARCH_RADIUS && *x < maxX) && (*y > ROBOT_SEARCH_RADIUS && *y < maxY)) {
+        // detect robot in 30px radius of drop location
+        for (int i = -ROBOT_SEARCH_RADIUS; i <= ROBOT_SEARCH_RADIUS; i++) {
+            for (int j = -ROBOT_SEARCH_RADIUS; j <= ROBOT_SEARCH_RADIUS; j++) {
+                curItem = itemAt(*x + i, *y + j, QTransform());
+                if ((robot = dynamic_cast<Robot*>(curItem))) {
+                    return true;
+                }
+           }
+        }
+    }
+    return false;
 }
 
 // Shows a pop up error message, press 'ok' to close

--- a/line_robots/canvas.cpp
+++ b/line_robots/canvas.cpp
@@ -94,14 +94,10 @@ QGraphicsLineItem* Canvas::detectLine(int *x, int *y){
                     *y+=j;
                     return line;
                 }
-            }
-        }
-        for (int i = 0; i >= -LINE_SEARCH_RADIUS; i--) {
-            for (int j = 0; j >= -LINE_SEARCH_RADIUS; j--){
-                curItem = itemAt(*x + i, *y + j, QTransform());
+                curItem = itemAt(*x - i, *y - j, QTransform());
                 if ((line = dynamic_cast<QGraphicsLineItem*>(curItem))) {
-                    *x+=i; //adjust coordinates
-                    *y+=j;
+                    *x-=i; //adjust coordinates
+                    *y-=j;
                     return line;
                 }
             }

--- a/line_robots/canvas.h
+++ b/line_robots/canvas.h
@@ -20,8 +20,10 @@ public:
     void errorMsg(int error);
 
 private:
-    const int SEARCH_RADIUS = 30;
+    const int LINE_SEARCH_RADIUS = 30;
+    const int ROBOT_SEARCH_RADIUS = 15;
     QGraphicsLineItem* detectLine(int *x, int *y);
+    bool detectRobot(int *x, int *y);
     QMenu *myItemMenu;
 };
 

--- a/line_robots/line_robots.pro.user
+++ b/line_robots/line_robots.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.12.0, 2020-05-19T15:45:43. -->
+<!-- Written by QtCreator 4.12.0, 2020-05-19T16:07:55. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/line_robots/mainwindow.cpp
+++ b/line_robots/mainwindow.cpp
@@ -23,30 +23,6 @@ MainWindow::MainWindow(QWidget *parent)
     //Smoth out the movement of the robot
     ui->canvas->setRenderHint(QPainter::Antialiasing);
 
-    //Draw out the boundry of the scene
-    // QPen mypen = QPen(Qt::black, 2);
-
-    // QLineF TopLine(scene->sceneRect().topLeft(), scene->sceneRect().topRight());
-    // QLineF LeftLine(scene->sceneRect().topLeft(), scene->sceneRect().bottomLeft());
-    // QLineF RightLine(scene->sceneRect().topRight(), scene->sceneRect().bottomRight());
-    // QLineF ButtomLine(scene->sceneRect().bottomLeft(), scene->sceneRect().bottomRight());
-
-    // scene->addLine(TopLine,mypen);
-    // scene->addLine(LeftLine,mypen);
-    // scene->addLine(RightLine,mypen);
-    // scene->addLine(ButtomLine,mypen);
-
-    // connect(ui->robotMenu, SIGNAL(Mouse_Pressed()), this, SLOT(Mouse_Pressed()));
-    //Add robot
-   // int RobotCount = 1;
-
-   // for(int i = 0; i< RobotCount; i++)
-   // {
-   //     MyRobot *Robot = new MyRobot();
-   //     scene->addItem(Robot);
-   // }
-
-
    // movement timer, advance is used for the progresion of the robot.
    timer = new pauseableTimer(this);
 
@@ -83,28 +59,4 @@ void MainWindow::setPause(bool timerActive){
 void MainWindow::on_butClear_clicked()
 {
     clearData();
-	
-    // QPen mypen = QPen(Qt::blue);
-
-    // QLineF TopLine(scene->sceneRect().topLeft(), scene->sceneRect().topRight());
-    // QLineF LeftLine(scene->sceneRect().topLeft(), scene->sceneRect().bottomLeft());
-    // QLineF RightLine(scene->sceneRect().topRight(), scene->sceneRect().bottomRight());
-    // QLineF ButtomLine(scene->sceneRect().bottomLeft(), scene->sceneRect().bottomRight());
-
-    // scene->addLine(TopLine,mypen);
-    // scene->addLine(LeftLine,mypen);
-    // scene->addLine(RightLine,mypen);
-    // scene->addLine(ButtomLine,mypen);
 }
-
-/*
-void MainWindow::Mouse_Pressed()
-{
-    int barSpeed1;
-    double barSpeed2;
-    barSpeed1 = ui->progressBar->value();
-    barSpeed2 = static_cast<double>(barSpeed1);
-}
-*/
-
-

--- a/line_robots/mainwindow.ui
+++ b/line_robots/mainwindow.ui
@@ -33,7 +33,7 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout_3">
-    <item row="0" column="0">
+    <item row="1" column="0">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
        <widget class="QGraphicsView" name="canvas">
@@ -63,6 +63,22 @@
         </property>
         <property name="lineWidth">
          <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QWidget" name="statusBar" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>10</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -229,22 +245,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QWidget" name="statusBar" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>10</height>
-         </size>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">

--- a/line_robots/robot.cpp
+++ b/line_robots/robot.cpp
@@ -28,19 +28,6 @@ void Robot::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWi
     QRectF rec = boundingRect();
     painter->setPen(Qt::black);
 
-    // TODO: reimplement collision detection code, current
-    // state doesn't work as robots would be in a state of
-    // constant collision since they are on a line.
-    // if(scene()->collidingItems(this).isEmpty())
-    // {
-    //     painter->setBrush(Qt::green);
-    // }
-    // else
-    // {
-    //     painter->setBrush(Qt::red);
-    //     DoCollision();
-    // }
-
     if (this->type == "Circle Robot") {
         painter->setBrush(Qt::green);
         painter->drawEllipse(rec);


### PR DESCRIPTION
Created a function to detect robots in a search radius of 30. I also modified the code in the detect line function. Instead of a for loop search from -30 to 30, I made the loop from 0 to 30 but added another check on the negative of the iterator. I made this change to improve the accuracy of the drop. Since we started at -30, the robot would always drop to the right of the cursor. This made it difficult when placing robots close together as the drop was unpredictable.